### PR TITLE
Bug fix #55: Pinning self text messages in groupchat

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -60,6 +60,7 @@ import org.thoughtcrime.securesms.database.RecipientDatabase;
 import org.thoughtcrime.securesms.database.loaders.ConversationLoader;
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
+import org.thoughtcrime.securesms.database.model.MmsMessageRecord;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.mms.OutgoingMediaMessage;
 import org.thoughtcrime.securesms.mms.Slide;
@@ -334,7 +335,7 @@ public class ConversationFragment extends Fragment
 
     if (pin) {
       // Blocking Video and Audio pinning Temporarily
-        if(message.isMms()) {
+        if(message.isMms() && ((MmsMessageRecord) message).getSlideDeck().getSlides().size() != 0) {
           MediaMmsMessageRecord mediaMessage = (MediaMmsMessageRecord) message;
           if (!mediaMessage.getSlideDeck().getThumbnailSlide().getContentType().contains("image")) {
             showToast("You can only pin image type mms!");

--- a/src/org/thoughtcrime/securesms/PinnedMessageAdapter.java
+++ b/src/org/thoughtcrime/securesms/PinnedMessageAdapter.java
@@ -31,6 +31,7 @@ import org.thoughtcrime.securesms.components.ThumbnailView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
+import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord;
 import org.thoughtcrime.securesms.mms.GlideRequests;
@@ -91,7 +92,7 @@ public class PinnedMessageAdapter extends RecyclerView.Adapter<PinnedMessageAdap
         MessageRecord         record = reader.getCurrent();
         this.setMessageView(record, holder);
 
-        if (record.isMms()) {
+        if (record.isMms() && ((MmsMessageRecord) record).getSlideDeck().getSlides().size() != 0) {
             ConversationItem                        conversationItem       = new ConversationItem(context);
             ConversationItem.ThumbnailClickListener thumbnailClickListener = conversationItem.new ThumbnailClickListener(record);
 


### PR DESCRIPTION
For some reason, the self-pinned text messages are rendered as MediaMessages which in fact they are simple text messages. The bug has been fixed by added another verification on top of isMms which basically check if the message casted to mms can return filled slider. Sliders tell us if the message contains an attachment.
