### PR TITLE
Group chat reaction bug fix

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -74,6 +74,7 @@ import com.google.protobuf.ByteString;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.json.JSONObject;
 import org.thoughtcrime.securesms.audio.AudioRecorder;
 import org.thoughtcrime.securesms.audio.AudioSlidePlayer;
 import org.thoughtcrime.securesms.color.MaterialColor;
@@ -172,8 +173,10 @@ import org.whispersystems.libsignal.util.guava.Optional;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static java.lang.System.currentTimeMillis;
@@ -796,8 +799,14 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
           e.printStackTrace();
         }
 
-        String body = "{\"type\": \"reaction\", \"hash\": \"" + messageRecord.getHash() + "\", \"emoji\": \"" +
-                emoji + "\", \"time\": \"" + time.toString() + "\",  \"address\": \"" + myAddress + "\" }";
+        Map<String, String> map = new HashMap<>();
+        map.put("type", "reaction");
+        map.put("hash", messageRecord.getHash());
+        map.put("emoji", emoji);
+        map.put("time", time.toString());
+        map.put("address", myAddress);
+
+        String body = new JSONObject(map).toString();
 
         if(recipient.getAddress().isGroup()) {
           sendMediaMessage(false, body, new SlideDeck(), 0,-1, false);

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -519,12 +519,14 @@ public class ConversationFragment extends Fragment implements LoaderManager.Load
     public long stageOutgoingMessage(OutgoingMediaMessage message) {
         MessageRecord messageRecord = DatabaseFactory.getMmsDatabase(getContext()).readerFor(message, threadId).getCurrent();
 
-        if (getListAdapter() != null) {
-            getListAdapter().setHeaderView(null);
-            setLastSeen(0);
-            getListAdapter().addFastRecord(messageRecord);
+        String messageBody = messageRecord.getBody().getBody();
+        if ((Stereotype.fromBody(messageBody).equals(Stereotype.UNKNOWN))) {
+            if (getListAdapter() != null) {
+                getListAdapter().setHeaderView(null);
+                setLastSeen(0);
+                getListAdapter().addFastRecord(messageRecord);
+            }
         }
-
         return messageRecord.getId();
     }
 

--- a/src/org/thoughtcrime/securesms/ReactionsHandler.java
+++ b/src/org/thoughtcrime/securesms/ReactionsHandler.java
@@ -43,7 +43,7 @@ public class ReactionsHandler {
      * @param reactorID
      * @param threadId
      */
-    public void addReactionToReceiverDB(String messageHash, String reaction, Long reactionTime, Address reactorID, Long threadId) {
+    public void addReactionToReceiverDB(String messageHash, String reaction, Long reactionTime, String reactorID, Long threadId) {
         this.reactionsDb.reactToMessage(messageHash, reaction, reactionTime, reactorID, threadId);
     }
 

--- a/src/org/thoughtcrime/securesms/database/MessageReactionDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MessageReactionDatabase.java
@@ -43,7 +43,7 @@ public class MessageReactionDatabase extends Database {
         super(context, databaseHelper);
     }
 
-    public void reactToMessage(String hash, String reaction, Long reactionDate, Address reactorID, Long threadId) {
+    public void reactToMessage(String hash, String reaction, Long reactionDate, String reactorID, Long threadId) {
         SQLiteDatabase db = databaseHelper.getWritableDatabase();
         String      type;
         ContentValues values = new ContentValues();
@@ -54,7 +54,7 @@ public class MessageReactionDatabase extends Database {
 
         values.put(type, hash);
         values.put(REACTION, reaction);
-        values.put(REACTOR_ID, reactorID.serialize());
+        values.put(REACTOR_ID, reactorID);
         values.put(REACTION_DATE, reactionDate);
         insertOrUpdate(values, type);
         notifyConversationListeners(threadId);

--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -61,6 +61,7 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
 import org.thoughtcrime.securesms.util.JsonUtils;
 import org.thoughtcrime.securesms.util.MessageHash;
+import org.thoughtcrime.securesms.util.Stereotype;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.jobqueue.JobManager;
@@ -930,8 +931,10 @@ public class MmsDatabase extends MessagingDatabase {
         insertListener.onComplete();
       }
 
-      notifyConversationListeners(contentValues.getAsLong(THREAD_ID));
-      DatabaseFactory.getThreadDatabase(context).update(contentValues.getAsLong(THREAD_ID), true);
+      if(Stereotype.fromBody(body).equals(Stereotype.UNKNOWN)) {
+        notifyConversationListeners(contentValues.getAsLong(THREAD_ID));
+        DatabaseFactory.getThreadDatabase(context).update(contentValues.getAsLong(THREAD_ID), true);
+      }
     }
   }
 

--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -651,7 +651,7 @@ public class PushDecryptJob extends ContextJob {
       ReactionsHandler handler = new ReactionsHandler(context);
       ObjectMapper mapper = new ObjectMapper();
       Map<String,String> map = mapper.readValue(body, Map.class);
-      handler.addReactionToReceiverDB(map.get("hash"), map.get("emoji"), Long.parseLong(map.get("time")), recipient.getAddress(),threadId );
+      handler.addReactionToReceiverDB(map.get("hash"), map.get("emoji"), Long.parseLong(map.get("time")), map.get("address"),threadId );
     } else {
       IncomingTextMessage textMessage = new IncomingTextMessage(Address.fromExternal(context, envelope.getSource()),
                                                                 envelope.getSourceDevice(),

--- a/src/org/thoughtcrime/securesms/jobs/PushTextSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushTextSendJob.java
@@ -16,6 +16,7 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.service.ExpiringMessageManager;
 import org.thoughtcrime.securesms.transport.InsecureFallbackApprovalException;
 import org.thoughtcrime.securesms.transport.RetryLaterException;
+import org.thoughtcrime.securesms.util.Stereotype;
 import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.SignalServiceMessageSender;
 import org.whispersystems.signalservice.api.crypto.UntrustedIdentityException;
@@ -57,7 +58,7 @@ public class PushTextSendJob extends PushSendJob implements InjectableType {
       deliver(record);
 
       String messageBody = record.getDisplayBody().toString();
-      if (messageBody.length() >= 19 && messageBody.substring(0, 19).equals("{\"type\": \"reaction\"")) {
+      if (!Stereotype.fromBody(messageBody).equals(Stereotype.UNKNOWN)) {
         database.deleteMessage(messageId);
       } else {
         database.markAsSent(messageId, true);


### PR DESCRIPTION
1- Added the address of the sender to the data message in order to prevent errors when the app tries to parse server address as regular address
2- added some logic in media messages sender pipeline since group chat reactions and messages are sent as media messages instead of regular text messages

